### PR TITLE
Fix React error #310: Use callback form for setState

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lesson Builder | Конструктор Уроків</title>
-    <!-- Security Headers managed by GitHub Pages -->
-    <!-- Additional Security Headers -->
-    <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="X-Frame-Options" content="DENY">
-    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
     <meta name="referrer" content="strict-origin-when-cross-origin">
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,12 +67,11 @@ function App() {
         setStudentLesson(shared);
         setStudentMode(true);
         // Auto-select language based on lesson or default to English
-        if (!language) {
-          setLanguage('en');
-        }
+        setLanguage(prev => prev || 'en');
       }
     }
-  }, [language]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Show student view if in student mode
   if (studentMode && studentLesson && language) {


### PR DESCRIPTION
Changed useEffect to use the callback form of setState instead of referencing language directly. This allows the effect to run only once on mount while still being able to access and update the language state safely.

Also removed invalid meta tags (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection) that can only be set via HTTP headers, not meta tags. These were generating console warnings without providing any security benefit.

Changes:
- Use setLanguage(prev => prev || 'en') instead of checking language
- Keep empty dependency array [] for one-time execution
- Remove meta tags that don't work in meta elements