### PR TITLE
Fix React error #310: Memoize shortcuts array

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import type { Lesson, Exercise } from './types';
 import type { Language } from './translations';
 import { getTranslation } from './translations';
@@ -218,7 +218,7 @@ function App() {
   };
 
   // Define keyboard shortcuts
-  const shortcuts: KeyboardShortcut[] = language ? [
+  const shortcuts: KeyboardShortcut[] = useMemo(() => language ? [
     {
       key: 's',
       ctrlKey: true,
@@ -279,7 +279,7 @@ function App() {
       description: language === 'en' ? 'Close modal' : 'Закрити модальне вікно',
       preventDefault: false,
     },
-  ] : [];
+  ] : [], [language, currentStep, lesson, showSampleLessons, showSavedLessons, showShortcutsHelp]);
 
   // Use keyboard shortcuts
   useKeyboardShortcuts(shortcuts, !!language && !studentMode);


### PR DESCRIPTION
Wrapped the shortcuts array in useMemo to prevent it from being recreated on every render. The shortcuts array was being passed to useKeyboardShortcuts hook, which has a useEffect that depends on it.

Since the array was recreated on every render (even with the same content), it caused the useEffect to re-run constantly, violating React's exhaustive-deps rule and throwing error #310 in production.

Now the array is only recreated when its actual dependencies change:
- language
- currentStep
- lesson
- showSampleLessons
- showSavedLessons
- showShortcutsHelp

This ensures stable reference identity and proper memoization.