### PR TITLE
Fix infinite render loop: Remove unnecessary useMemo dependencies

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -279,7 +279,7 @@ function App() {
       description: language === 'en' ? 'Close modal' : 'Закрити модальне вікно',
       preventDefault: false,
     },
-  ] : [], [language, currentStep, lesson, showSampleLessons, showSavedLessons, showShortcutsHelp]);
+  ] : [], [language, currentStep]);
 
   // Use keyboard shortcuts
   useKeyboardShortcuts(shortcuts, !!language && !studentMode);


### PR DESCRIPTION
Reduced useMemo dependencies from [language, currentStep, lesson, showSampleLessons, showSavedLessons, showShortcutsHelp] to just [language, currentStep].

The issue was that including 'lesson' and the show* state variables caused the shortcuts array to be recreated on every state change, triggering the useEffect in useKeyboardShortcuts repeatedly and creating an infinite render loop (React error #310).

The shortcuts array only needs to be recreated when:
- language changes (affects descriptions)
- currentStep changes (affects conditional logic in export/print)

The other values (lesson, showSampleLessons, etc.) are captured in the action function closures and don't need to trigger recreation.